### PR TITLE
fix screenshot on CX II-T (color screen with 16 bits per pixel)

### DIFF
--- a/libnspire-sys/build.rs
+++ b/libnspire-sys/build.rs
@@ -4,7 +4,6 @@ fn main() {
     let files = globwalk::GlobWalkerBuilder::from_patterns("libnspire/src", &["*.{c,cpp}"])
         .build()
         .unwrap()
-        .into_iter()
         .filter_map(Result::ok)
         .map(DirEntry::into_path)
         .inspect(|path| println!("cargo:rerun-if-changed={}", path.display()));

--- a/libnspire-sys/libnspire/src/api/screenshot.h
+++ b/libnspire-sys/libnspire/src/api/screenshot.h
@@ -23,7 +23,7 @@
 
 struct nspire_image {
 	uint16_t width, height;
-	uint8_t bbp;
+	uint8_t bpp;
 
 	unsigned char data[];
 };

--- a/libnspire-sys/src/bindings.rs
+++ b/libnspire-sys/src/bindings.rs
@@ -721,7 +721,7 @@ extern "C" {
 pub struct nspire_image {
     pub width: u16,
     pub height: u16,
-    pub bbp: u8,
+    pub bpp: u8,
     pub data: __IncompleteArrayField<::std::os::raw::c_uchar>,
 }
 #[test]
@@ -757,13 +757,13 @@ fn bindgen_test_layout_nspire_image() {
         )
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<nspire_image>())).bbp as *const _ as usize },
+        unsafe { &(*(::std::ptr::null::<nspire_image>())).bpp as *const _ as usize },
         4usize,
         concat!(
             "Offset of field: ",
             stringify!(nspire_image),
             "::",
-            stringify!(bbp)
+            stringify!(bpp)
         )
     );
     assert_eq!(

--- a/libnspire/src/lib.rs
+++ b/libnspire/src/lib.rs
@@ -154,7 +154,7 @@ impl<T: UsbContext> Handle<T> {
                 cb.as_mut_void(),
             ))?;
         }
-        Ok(bytes as usize)
+        Ok(bytes)
     }
 
     /// Write a file.

--- a/libnspire/src/lib.rs
+++ b/libnspire/src/lib.rs
@@ -73,14 +73,14 @@ impl<T: UsbContext> Handle<T> {
             err(nspire_screenshot(self.handle.as_ptr(), &mut image))?;
             let width = (*image).width;
             let height = (*image).height;
-            let bbp = (*image).bbp;
-            let len = (width as u32 * height as u32 * bbp as u32) / 8;
+            let bpp = (*image).bpp;
+            let len = (width as u32 * height as u32 * bpp as u32) / 8;
             let data = (*image).data.as_slice(len as usize).into();
             free(image as _);
             Ok(Image {
                 width,
                 height,
-                bpp: bbp,
+                bpp,
                 data,
             })
         }

--- a/libnspire/src/lib.rs
+++ b/libnspire/src/lib.rs
@@ -20,6 +20,9 @@ use libnspire_sys::{
 };
 use std::convert::TryFrom;
 
+#[cfg(feature = "image")]
+use image::{DynamicImage, ImageBuffer};
+
 mod callback;
 pub mod dir;
 mod error;
@@ -242,40 +245,54 @@ pub struct Image {
     pub bpp: u8,
     pub data: Vec<u8>,
 }
-const MAX_R: u8 = ((1usize << 5) - 1) as u8;
-const MAX_G: u8 = ((1usize << 6) - 1) as u8;
-const MAX_B: u8 = ((1usize << 5) - 1) as u8;
+
+const B_BITS: usize = 5;
+const G_BITS: usize = 6;
+const R_BITS: usize = 5;
+
+const B_OFFSET: usize = 0;
+const G_OFFSET: usize = B_OFFSET + B_BITS;
+const R_OFFSET: usize = G_OFFSET + G_BITS;
+
+const _: () = {
+    if R_OFFSET + R_BITS != 16 {
+        panic!("total length must be 16");
+    }
+};
+
+const MAX_B: u8 = (1 << B_BITS) - 1;
+const MAX_G: u8 = (1 << G_BITS) - 1;
+const MAX_R: u8 = (1 << R_BITS) - 1;
+
 /// Convert color channel values from one bit depth to another.
 const fn convert_channel(value: u8, from_max: u8) -> u8 {
-    ((value as u16 * 255u16 + from_max as u16 / 2) / from_max as u16) as u8
+    ((value as u16 * 255 + from_max as u16 / 2) / from_max as u16) as u8
 }
 
 #[cfg(feature = "image")]
-impl TryFrom<Image> for image::DynamicImage {
+impl TryFrom<Image> for DynamicImage {
     type Error = Error;
 
     /// Currently broken.
     fn try_from(image: Image) -> Result<Self> {
-        use image::ImageBuffer;
         match image.bpp {
-            8 => Ok(image::DynamicImage::ImageLuma8(
+            8 => Ok(DynamicImage::ImageLuma8(
                 ImageBuffer::from_vec(image.width as u32, image.height as u32, image.data).unwrap(),
             )),
             16 => {
-                let data: Vec<u8> = image
+                let data: Vec<_> = image
                     .data
-                    .chunks(2)
+                    .chunks_exact(2)
                     .flat_map(|d| {
-                        let color = u16::from_ne_bytes([d[0], d[1]]);
+                        let color = u16::from_le_bytes([d[0], d[1]]);
                         ArrayIterator::new([
-                            convert_channel(color as u8 & MAX_R, MAX_R),
-                            convert_channel((color >> 5) as u8 & MAX_G, MAX_G),
-                            convert_channel((color >> 11) as u8 & MAX_B, MAX_B),
+                            convert_channel((color >> R_OFFSET) as u8 & MAX_R, MAX_R),
+                            convert_channel((color >> G_OFFSET) as u8 & MAX_G, MAX_G),
+                            convert_channel((color >> B_OFFSET) as u8 & MAX_B, MAX_B),
                         ])
                     })
                     .collect();
-                dbg!(data.len());
-                Ok(image::DynamicImage::ImageRgb8(
+                Ok(DynamicImage::ImageRgb8(
                     ImageBuffer::from_vec(image.width as u32, image.height as u32, data).unwrap(),
                 ))
             }


### PR DESCRIPTION
i needed [this](https://github.com/Vogtinator/libnspire/commit/7d7d962ca49ff9017f6f146336c51ef7f2edf4e0) commit of Vogtinator/libnspire for screenshots to work on my CX II-T, after this i got a screenshot with red and blue swapped, apparently the calculator sends bgr instead of rgb, swapping these two in the conversion function did the trick and gave me a screenshot with the right colors

this pr probably wont work out of the box, when testing i set the dependency of libnspire on libnspire-sys to `libnspire-sys = { path = "../libnspire-sys" }` (libnspire/Cargo.toml), which i left untouched for this pr