### PR TITLE
Bumped dependencies and updated cargo edition to 2024

### DIFF
--- a/libnspire-sys/Cargo.toml
+++ b/libnspire-sys/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "libnspire-sys"
 description = "low-level FFI bindings to libnspire for USB interaction with TI Nspire calculators"
-version = "0.3.3"
+version = "0.3.5"
 authors = ["lights0123 <developer@lights0123.com>"]
-edition = "2018"
+edition = "2024"
 build = "build.rs"
 links = "nspire"
 license = "GPL-3.0"
@@ -13,9 +13,9 @@ repository = "https://github.com/lights0123/libnspire-rs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-libusb1-sys = "0.4.1"
+libusb1-sys = "0.7.0"
 
 [build-dependencies]
-cc = { version = "1.0", features = ["parallel"] }
-globwalk = "0.7"
-# bindgen = "0.55.1"
+cc = { version = "1.2.34", features = ["parallel"] }
+globwalk = "0.9.1"
+# bindgen = "0.72.0"

--- a/libnspire-sys/src/bindings.rs
+++ b/libnspire-sys/src/bindings.rs
@@ -33,7 +33,7 @@ impl<T> ::std::fmt::Debug for __IncompleteArrayField<T> {
 pub type __uint8_t = ::std::os::raw::c_uchar;
 pub type __uint16_t = ::std::os::raw::c_ushort;
 pub type __uint64_t = ::std::os::raw::c_ulong;
-extern "C" {
+unsafe extern "C" {
     pub fn free(__ptr: *mut ::std::os::raw::c_void);
 }
 #[repr(C)]
@@ -47,14 +47,14 @@ pub type nspire_handle_t = nspire_handle;
 pub struct libusb_device_handle {
     _unused: [u8; 0],
 }
-extern "C" {
+unsafe extern "C" {
     pub fn nspire_init(
         ptr: *mut *mut nspire_handle_t,
         dev: *mut libusb_device_handle,
         is_cx2: bool,
     ) -> ::std::os::raw::c_int;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn nspire_free(ptr: *mut nspire_handle_t);
 }
 pub const nspire_battery_NSPIRE_BATT_POWERED: nspire_battery = 0;
@@ -510,7 +510,7 @@ fn bindgen_test_layout_nspire_devinfo() {
         )
     );
 }
-extern "C" {
+unsafe extern "C" {
     pub fn nspire_device_info(
         handle: *mut nspire_handle_t,
         i: *mut nspire_devinfo,
@@ -518,7 +518,7 @@ extern "C" {
 }
 pub type nspire_callback =
     ::std::option::Option<unsafe extern "C" fn(arg1: usize, arg2: *mut ::std::os::raw::c_void)>;
-extern "C" {
+unsafe extern "C" {
     pub fn nspire_file_write(
         arg1: *mut nspire_handle_t,
         arg2: *const ::std::os::raw::c_char,
@@ -528,7 +528,7 @@ extern "C" {
         cb_data: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn nspire_file_read(
         handle: *mut nspire_handle_t,
         path: *const ::std::os::raw::c_char,
@@ -539,21 +539,21 @@ extern "C" {
         cb_data: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn nspire_file_move(
         handle: *mut nspire_handle_t,
         src: *const ::std::os::raw::c_char,
         dst: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn nspire_file_copy(
         handle: *mut nspire_handle_t,
         src: *const ::std::os::raw::c_char,
         dst: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn nspire_file_delete(
         handle: *mut nspire_handle_t,
         path: *const ::std::os::raw::c_char,
@@ -661,29 +661,29 @@ fn bindgen_test_layout_nspire_dir_info() {
         )
     );
 }
-extern "C" {
+unsafe extern "C" {
     pub fn nspire_dirlist(
         arg1: *mut nspire_handle_t,
         arg2: *const ::std::os::raw::c_char,
         arg3: *mut *mut nspire_dir_info,
     ) -> ::std::os::raw::c_int;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn nspire_dirlist_free(d: *mut nspire_dir_info);
 }
-extern "C" {
+unsafe extern "C" {
     pub fn nspire_dir_create(
         handle: *mut nspire_handle_t,
         path: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn nspire_dir_delete(
         handle: *mut nspire_handle_t,
         path: *const ::std::os::raw::c_char,
     ) -> ::std::os::raw::c_int;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn nspire_attr(
         arg1: *mut nspire_handle_t,
         arg2: *const ::std::os::raw::c_char,
@@ -704,10 +704,10 @@ pub const NSPIRE_ERR_NONEXIST: ::std::os::raw::c_uint = 10;
 pub const NSPIRE_ERR_OSFAILED: ::std::os::raw::c_uint = 11;
 pub const NSPIRE_ERR_MAX: ::std::os::raw::c_uint = 12;
 pub type _bindgen_ty_5 = ::std::os::raw::c_uint;
-extern "C" {
+unsafe extern "C" {
     pub fn nspire_strerror(error: ::std::os::raw::c_int) -> *const ::std::os::raw::c_char;
 }
-extern "C" {
+unsafe extern "C" {
     pub fn nspire_os_send(
         handle: *mut nspire_handle_t,
         data: *mut ::std::os::raw::c_void,
@@ -777,7 +777,7 @@ fn bindgen_test_layout_nspire_image() {
         )
     );
 }
-extern "C" {
+unsafe extern "C" {
     pub fn nspire_screenshot(
         handle: *mut nspire_handle_t,
         ptr: *mut *mut nspire_image,

--- a/libnspire/Cargo.toml
+++ b/libnspire/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "libnspire"
 description = "high-level bindings to libnspire for USB interaction with TI Nspire calculators"
-version = "0.2.3"
+version = "0.2.4"
 authors = ["lights0123 <developer@lights0123.com>"]
-edition = "2018"
+edition = "2024"
 license = "GPL-3.0"
 readme = "README.md"
 repository = "https://github.com/lights0123/libnspire-rs"
@@ -14,15 +14,15 @@ repository = "https://github.com/lights0123/libnspire-rs"
 default = ["image", "serde"]
 
 [dependencies]
-array_iterator = "0.2.4"
-libnspire-sys = "0.3.0"
-libusb1-sys = "0.4.2"
-image = { version = "0.23.9", default-features = false, optional = true }
-serde = { version = "1.0.116", features = ["derive"], optional = true }
-rusb = "0.6.4"
-thiserror = "1.0.20"
-displaydoc = "0.1"
+array_iterator = "1.8.0"
+libnspire-sys = { path = "../libnspire-sys"}
+libusb1-sys = "0.7.0"
+image = { version = "0.25.6", default-features = false, optional = true }
+serde = { version = "1.0.219", features = ["derive"], optional = true }
+rusb = "0.9.4"
+thiserror = "2.0.16"
+displaydoc = "0.2.5"
 
 [dev-dependencies]
-image = { version = "0.23.9" }
-serde_json = "1.0.57"
+image = { version = "0.25.6" }
+serde_json = "1.0.143"


### PR DESCRIPTION
Note for the future: Rust is looking to change unsafe flags further to include the whole function. Most of the functions in libnspire-sys are under [#test], which doesn't allow unsafe functions. This could possibly become an error in future cargo editions.

Oh, and as a work around in libnspire for the existing libnspire-sys on crates.io not liking libusb 0.7.0, I made the dependency into a local path. That'll need to be changed once the crates version is updated.